### PR TITLE
Strategy options now can be a callback function

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ The JWT authentication strategy is constructed as follows:
 
     new JwtStrategy(options, verify)
 
-`options` is an object literal containing options to control how the token is
-extracted from the request or verified.
+`options` is an object literal (or a function, see the __Dynamic options__ section below)
+containing options to control how the token is extracted from the request or verified.
 
 * `secretOrKey` is a REQUIRED string or buffer containing the secret
   (symmetric) or PEM-encoded public key (asymmetric) for verifying the token's
   signature.
 
 * `jwtFromRequest` (REQUIRED) Function that accepts a request as the only
-  parameter and returns either the JWT as a string or *null*. See 
+  parameter and returns either the JWT as a string or *null*. See
   [Extracting the JWT from the request](#extracting-the-jwt-from-the-request) for
   more details.
 * `issuer`: If defined the token issuer (iss) will be verified against this
@@ -81,7 +81,7 @@ possible the JWT is parsed from the request by a user-supplied callback passed i
 `jwtFromRequest` parameter.  This callback, from now on referred to as an extractor,
 accepts a request object as an argument and returns the encoded JWT string or *null*.
 
-#### Included extractors 
+#### Included extractors
 
 A number of extractor factory functions are provided in passport-jwt.ExtractJwt. These factory
 functions return a new extractor configured with the given parameters.
@@ -102,7 +102,7 @@ functions return a new extractor configured with the given parameters.
 ### Writing a custom extractor function
 
 If the supplied extractors don't meet your needs you can easily provide your own callback. For
-example, if you are using the cookie-parser middleware and want to extract the JWT in a cookie 
+example, if you are using the cookie-parser middleware and want to extract the JWT in a cookie
 you could use the following function as the argument to the jwtFromRequest option:
 
 ```
@@ -144,6 +144,34 @@ body will be checked for a field matching either `options.tokenBodyField` or
 Finally, the URL query parameters will be checked for a field matching either
 `options.tokenQueryParameterName` or `auth_token` if the option was not
 specified.
+
+### Dynamic options
+
+The options given to the `JwtStrategy` constructor can be a function,
+which will be called each time that Passport will use this strategy to
+authenticate a request.
+
+This can be useful when your JWT options can change (i.e. read from a file or
+a database), or in case of multi-tenanted applications.
+
+```js
+function optionsResolver(req, callback) {
+  // do something with the req object
+  myOptionsProvider(function(options) {
+    if (!options) {
+      callback(new Error('No options found'));
+    } else {
+      callback(null, options);
+    }
+  });
+}
+
+...
+
+passport.use(new JwtStrategy(optionsResolver, verify))
+```
+
+
 
 ## Migrating from version 1.x.x to 2.x.x
 

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -1,7 +1,5 @@
 var passport = require('passport-strategy')
-    , auth_hdr = require('./auth_header')
-    , util = require('util')
-    , url = require('url');
+    , util = require('util');
 
 
 
@@ -24,41 +22,22 @@ function JwtStrategy(options, verify) {
     passport.Strategy.call(this);
     this.name = 'jwt';
 
-    this._secretOrKey = options.secretOrKey;
-    if (!this._secretOrKey) {
-        throw new TypeError('JwtStrategy requires a secret or key');
+    var getOptions = options;
+
+    if (typeof options !== 'function') {
+        getOptions = function(req, callback) { return callback(null, options); };
     }
+
+    this._getOptions = function(req, callback) {
+        return getOptions(req, _qualifyOptions(callback));
+    };
 
     this._verify = verify;
     if (!this._verify) {
         throw new TypeError('JwtStrategy requires a verify callback');
     }
 
-    this._jwtFromRequest = options.jwtFromRequest;
-    if (!this._jwtFromRequest) {
-        throw new TypeError('JwtStrategy requires a function to retrieve jwt from requests (see option jwtFromRequest)');
-    }
-
-    this._passReqToCallback = options.passReqToCallback;
-    this._verifOpts = {};
-
-    if (options.issuer) {
-        this._verifOpts.issuer = options.issuer;
-    }
-
-    if (options.audience) {
-        this._verifOpts.audience = options.audience;
-    }
-
-    if (options.algorithms) {
-        this._verifOpts.algorithms = options.algorithms;
-    }
-
-    if (options.ignoreExpiration != null) {
-        this._verifOpts.ignoreExpiration = options.ignoreExpiration;
-    }
-
-};
+}
 util.inherits(JwtStrategy, passport.Strategy);
 
 
@@ -73,47 +52,106 @@ util.inherits(JwtStrategy, passport.Strategy);
  */
 JwtStrategy.JwtVerifier = require('./verify_jwt');
 
+/**
+ * Returns a function to qualify the options then call callback with the
+ * qualified options
+ */
+function _qualifyOptions(callback) {
+  return function(err, options) {
+    var result = {};
+
+    if (err) {
+      return callback(err);
+    }
+
+    if (!options) {
+        return callback(new TypeError('options cannot be null'));
+    }
+
+    result._secretOrKey = options.secretOrKey;
+    if (!result._secretOrKey) {
+        return callback(new TypeError('JwtStrategy requires a secret or key'));
+    }
+
+    result.jwtFromRequest = options.jwtFromRequest;
+    if (!result.jwtFromRequest) {
+        return callback(new TypeError('JwtStrategy requires a function to retrieve jwt from requests (see option jwtFromRequest)'));
+    }
+
+    result.passReqToCallback = options.passReqToCallback;
+    result.verifOpts = {};
+
+    if (options.issuer) {
+        result.verifOpts.issuer = options.issuer;
+    }
+
+    if (options.audience) {
+        result.verifOpts.audience = options.audience;
+    }
+
+    if (options.algorithms) {
+        result.verifOpts.algorithms = options.algorithms;
+    }
+
+    if (options.ignoreExpiration != null) {
+        result.verifOpts.ignoreExpiration = options.ignoreExpiration;
+    }
+
+    callback(null, result);
+  };
+
+}
 
 
 /**
  * Authenticate request based on JWT obtained from header or post body
  */
-JwtStrategy.prototype.authenticate = function(req, options) {
+JwtStrategy.prototype.authenticate = function(req) {
     var self = this;
 
-    var token = self._jwtFromRequest(req);
+    self._getOptions(req, function(err, options) {
+      if (err) {
+          return self.fail(err);
+      }
 
-    if (!token) {
-        return self.fail(new Error("No auth token"));
-    }
+      var token = options.jwtFromRequest(req);
 
-    // Verify the JWT
-    JwtStrategy.JwtVerifier(token, this._secretOrKey, this._verifOpts, function(jwt_err, payload) {
-        if (jwt_err) {
-            return self.fail(jwt_err);
-        } else {
-            // Pass the parsed token to the user
-            var verified = function(err, user, info) {
-                if(err) {
-                    return self.error(err);
-                } else if (!user) {
-                    return self.fail(info);
-                } else {
-                    return self.success(user, info);
-                }
-            };
+      if (!token) {
+          return self.fail(new Error("No auth token"));
+      }
 
-            try {
-                if (self._passReqToCallback) {
-                    self._verify(req, payload, verified);
-                } else {
-                    self._verify(payload, verified);
-                }
-            } catch(ex) {
-                self.error(ex);
-            }
-        }
+      // Verify the JWT
+      JwtStrategy.JwtVerifier(token, options._secretOrKey, options.verifOpts, function(jwt_err, payload) {
+          if (jwt_err) {
+              return self.fail(jwt_err);
+          }
+
+          // Pass the parsed token to the user
+          var verified = function(err, user, info) {
+              if (err) {
+                  return self.error(err);
+              }
+
+              if (!user) {
+                  return self.fail(info);
+              }
+
+              return self.success(user, info);
+          };
+
+          try {
+              if (options.passReqToCallback) {
+                  self._verify(req, payload, verified);
+              } else {
+                  self._verify(payload, verified);
+              }
+          } catch(ex) {
+              self.error(ex);
+          }
+      });
+
     });
+
 };
 
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "chai-passport-strategy": "^1.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.0.0",
-    "sinon": "^1.0.0"
+    "sinon": "^1.0.0",
+    "sinon-chai": "^2.8.0"
   },
   "dependencies": {
     "jsonwebtoken": "^7.0.0",

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -1,3 +1,4 @@
 var chai = require('chai');
 chai.use(require('chai-passport-strategy'));
+chai.use(require('sinon-chai'));
 global.expect = chai.expect;

--- a/test/strategy-init-test.js
+++ b/test/strategy-init-test.js
@@ -1,3 +1,4 @@
+var sinon = require('sinon');
 var Strategy = require('../lib/strategy');
 
 describe('Strategy', function() {
@@ -15,16 +16,70 @@ describe('Strategy', function() {
     });
 
 
-    it('should throw if constructed without a secretOrKey arg', function() {
-        expect(function() {
-            var s = new Strategy({jwtFromRequest: function(r) {}, secretOrKey: null}, function() {});
-        }).to.throw(TypeError, 'JwtStrategy requires a secret or key');
+    it('should have _getOptions function to return qualified options', function() {
+        var options = { jwtFromRequest: function() {}, secretOrKey: 'secret' };
+        var qualifiedOptions = {
+            _secretOrKey: options.secretOrKey,
+            jwtFromRequest: options.jwtFromRequest,
+            passReqToCallback: undefined,
+            verifOpts: {}
+        };
+        var strategy = new Strategy(options, function() {});
+        var callbackSpy = sinon.spy();
+
+        strategy._getOptions(null, callbackSpy);
+
+        expect(callbackSpy).to.have.been.calledWith(null, qualifiedOptions);
     });
 
 
-    it('should throw if constructed without a jwtFromRequest arg', function() {
-        expect(function() {
-            var s = new Strategy({secretOrKey: 'secret'}, function() {});
-        }).to.throw(TypeError);
+    it('should accept options as a function', function() {
+      var options = { jwtFromRequest: function() {}, secretOrKey: 'secret' };
+      var getOptions = function(req, callback) { callback(null, options); };
+      var qualifiedOptions = {
+          _secretOrKey: options.secretOrKey,
+          jwtFromRequest: options.jwtFromRequest,
+          passReqToCallback: undefined,
+          verifOpts: {}
+      };
+
+      var strategy = new Strategy(getOptions, function() {});
+      var callbackSpy = sinon.spy();
+
+      strategy._getOptions(null, callbackSpy);
+
+      expect(callbackSpy).to.have.been.calledWith(null, qualifiedOptions);
+    });
+
+    it('should call callback with error if constructed without options', function(done) {
+      var options = null;
+      var strategy = new Strategy(options, function() {});
+
+      strategy._getOptions(null, function(err) {
+          expect(err.message).to.equal('options cannot be null');
+          done();
+      });
+    });
+
+
+    it('should call callback with error if constructed without a secretOrKey arg', function(done) {
+      var options = { jwtFromRequest: function() {}, secretOrKey: null };
+      var strategy = new Strategy(options, function() {});
+
+      strategy._getOptions(null, function(err) {
+          expect(err.message).to.equal('JwtStrategy requires a secret or key');
+          done();
+      });
+    });
+
+
+    it('should call callback with error if constructed without a jwtFromRequest arg', function(done) {
+      var options = { secretOrKey: 'secret' };
+      var strategy = new Strategy(options, function() {});
+
+      strategy._getOptions(null, function(err) {
+          expect(err.message).to.equal('JwtStrategy requires a function to retrieve jwt from requests (see option jwtFromRequest)');
+          done();
+      });
     });
 });

--- a/test/strategy-requests-test.js
+++ b/test/strategy-requests-test.js
@@ -2,8 +2,7 @@ var Strategy = require('../lib/strategy')
     , chai = require('chai')
     , sinon = require('sinon')
     , test_data= require('./testdata')
-    , url = require('url')
-    , extract_jwt = require('../lib/extract_jwt')
+    , url = require('url');
 
 
 describe('Strategy', function() {
@@ -17,15 +16,14 @@ describe('Strategy', function() {
         mockVerifier.callsArgWith(3, null, test_data.valid_jwt.payload);
         Strategy.JwtVerifier = mockVerifier;
     });
-    
+
 
 
     describe('handling request JWT present in request', function() {
-        var strategy;
 
         before(function(done) {
-            strategy = new Strategy({
-                    jwtFromRequest: function (r) { return test_data.valid_jwt.token; },
+            var strategy = new Strategy({
+                    jwtFromRequest: function () { return test_data.valid_jwt.token; },
                     secretOrKey: 'secret'
                 },
                 function(jwt_payload, next) {
@@ -33,11 +31,11 @@ describe('Strategy', function() {
                     return next(null, {}, {});
                 }
             );
-            
+
             mockVerifier.reset();
-           
+
             chai.passport.use(strategy)
-                .success(function(u, i) {
+                .success(function() {
                     done();
                 })
                 .authenticate();
@@ -57,13 +55,13 @@ describe('Strategy', function() {
         var info;
 
         before(function(done) {
-            strategy = new Strategy({jwtFromRequest: function(r) {}, secretOrKey: 'secret'}, function(jwt_payload, next) {
+            var strategy = new Strategy({jwtFromRequest: function() {}, secretOrKey: 'secret'}, function(jwt_payload, next) {
                 // Return values aren't important in this case
                 return next(null, {}, {});
             });
-            
+
             mockVerifier.reset();
-           
+
             chai.passport.use(strategy)
                 .fail(function(i) {
                     info = i
@@ -88,12 +86,65 @@ describe('Strategy', function() {
 
     });
 
+    describe('handling request with dynamic options', function() {
+
+        var info, optionsCallback;
+
+        before(function() {
+            var strategy = new Strategy(function(req, callback) {
+                optionsCallback = callback;
+            }, function(jwt_payload, next) {
+                // Return values aren't important in this case
+                return next(null, {}, {});
+            });
+
+            mockVerifier.reset();
+
+            chai.passport.use(strategy)
+                .fail(function(i) {
+                    info = i
+                })
+                .req(function(req) {
+                    req.body = {}
+                })
+                .success(function() {})
+                .authenticate();
+        });
+
+
+        it('should fail authentication when resolved as an error', function() {
+            optionsCallback(new Error('expected error message'));
+
+            expect(info).to.be.an.object;
+            expect(info.message).to.equal('expected error message');
+        });
+
+        it('should fail authentication when resolved with undefined options', function() {
+            optionsCallback(null, null);
+
+            expect(info).to.be.an.object;
+            expect(info.message).to.equal('options cannot be null');
+        });
+
+        it('should work when resolved with valid options', function() {
+          var validOptions = {
+              jwtFromRequest: function () { return test_data.valid_jwt.token; },
+              secretOrKey: 'secret'
+          };
+
+          optionsCallback(null, validOptions);
+
+          sinon.assert.calledOnce(mockVerifier);
+          expect(mockVerifier.args[0][0]).to.equal(test_data.valid_jwt.token);
+        });
+    });
+
     describe('handling request url set to url.Url instead of string', function() {
 
         var info;
 
         before(function(done) {
-            strategy = new Strategy({jwtFromRequest: function(r) {}, secretOrKey: 'secret'}, function(jwt_payload, next) {
+            var strategy = new Strategy({jwtFromRequest: function() {}, secretOrKey: 'secret'}, function(jwt_payload, next) {
                 // Return values aren't important in this case
                 return next(null, {}, {});
             });


### PR DESCRIPTION
Usage:

```js
function optionsResolver(req, callback) {
  // do something with the req object
  myOptionsProvider(function(options) {
    if (!options) {
      callback(new Error('No options found'));
    } else {
      callback(null, options);
    }
  });
}

...

passport.use(new JwtStrategy(optionsResolver, verify))
```

Fixes #45 #37 
See also #46 #38 